### PR TITLE
Fix publications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.5.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/ormlite-sqlcipher/build.gradle
+++ b/ormlite-sqlcipher/build.gradle
@@ -57,7 +57,9 @@ android {
     tasks.withType(Javadoc).all { enabled = false }
 
     publishing {
-        singleVariant('release')
+        singleVariant('release') {
+            withSourcesJar()
+        }
     }
 }
 

--- a/ormlite-sqlcipher/build.gradle
+++ b/ormlite-sqlcipher/build.gradle
@@ -55,13 +55,17 @@ android {
     }
 
     tasks.withType(Javadoc).all { enabled = false }
+
+    publishing {
+        singleVariant('release')
+    }
 }
 
 afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                from components.findByName('release')
+                from components.release
                 groupId = "com.patientmpower.ormliteSqlcipher"
                 artifactId = "ormlite-sqlcipher"
                 version = '2.0.4'


### PR DESCRIPTION
Dear @jakub-pmp 

Thank you for updating this project. I'm trying to reanimate an old project and this is of great help!

I noticed, however, that as-is this doesn't publish any artifacts, only the POM-file:
```
~/.m2 $ find . -name '*ormlite*'
./repository/com/patientmpower/ormliteSqlcipher
./repository/com/patientmpower/ormliteSqlcipher/ormlite-sqlcipher
./repository/com/patientmpower/ormliteSqlcipher/ormlite-sqlcipher/2.0.4/ormlite-sqlcipher-2.0.4.pom
```

Here is a patch to actually publish the release build.

After these changes, the actual AAR file gets published:
```
 ~/.m2 $ find . -name '*ormlite*'
./repository/com/patientmpower/ormliteSqlcipher
./repository/com/patientmpower/ormliteSqlcipher/ormlite-sqlcipher
./repository/com/patientmpower/ormliteSqlcipher/ormlite-sqlcipher/2.0.4/ormlite-sqlcipher-2.0.4.aar
./repository/com/patientmpower/ormliteSqlcipher/ormlite-sqlcipher/2.0.4/ormlite-sqlcipher-2.0.4-sources.jar
./repository/com/patientmpower/ormliteSqlcipher/ormlite-sqlcipher/2.0.4/ormlite-sqlcipher-2.0.4.pom
./repository/com/patientmpower/ormliteSqlcipher/ormlite-sqlcipher/2.0.4/ormlite-sqlcipher-2.0.4.module
```